### PR TITLE
fix: transformHtml(...).replace is not a function

### DIFF
--- a/packages/quasar-app-extension-ssg/src/vite/ssg-devserver.js
+++ b/packages/quasar-app-extension-ssg/src/vite/ssg-devserver.js
@@ -158,10 +158,9 @@ class SsgDevServer extends AppDevserver {
       const template = readFileSync(templatePath, 'utf-8');
       this.#renderTemplate = getDevSsrTemplateFn(template, quasarConf);
 
-      this.#fallbackHtml = transformHtml(template, quasarConf).replace(
-        entryPointMarkup,
-        attachMarkup,
-      );
+      transformHtml(template, quasarConf).then((html) => {
+        this.#fallbackHtml = html.replace(entryPointMarkup, attachMarkup);
+      })
     };
 
     updateTemplate();


### PR DESCRIPTION
I'm not sure if it's just me. 

When I was using `quasar ssg dev` I got the following error

```shell
TypeError: transformHtml(...).replace is not a function
    at updateTemplate
```

And I noticed that the transformHtml function returned a Promise, I change the code so it works, at least for me. Can anyone please check?